### PR TITLE
Update supported Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 keywords = ["http", "requests", "credentials"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312,313},pypy{38,39,310},code
+envlist = py{39,310,311,312,313,314},pypy{310,311},code
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Drop support for Python 3.8, PyPy 3.8 and PyPy 3.9.

Add support for Python 3.14 and PyPy 3.11.